### PR TITLE
Add xmlrpc to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "bugs": {
     "url": "https://github.com/jbnv/Wikidot/issues"
   },
-  "homepage": "https://github.com/jbnv/Wikidot"
+  "homepage": "https://github.com/jbnv/Wikidot",
+  "dependencies": {
+    "xmlrpc": "^1.3.2"
+  }
 }


### PR DESCRIPTION
By adding xmlrpc, you can install the package just with `npm i wikidot` instead of `npm i wikidot xmlrpc`